### PR TITLE
Inject state

### DIFF
--- a/example/src/app.js
+++ b/example/src/app.js
@@ -1,14 +1,14 @@
-import { contextTypes } from "../..";
+import { injectState } from "../..";
 import { default as React } from "react";
 
 import addState from "./state";
 import ChildComponent from "./child-component";
 
 
-export const App = (props, { state, effects }) => {
+export const App = ({ rootProp, state, effects }) => {
   return (
     <div>
-      <div>{ props.rootProp }</div>
+      <div>{ rootProp }</div>
       <div>{ state.todosInfo }</div>
       <button onClick={() => effects.fetchTodos("https://jsonplaceholder.typicode.com/todos")}>
         Click me to fetch!
@@ -21,7 +21,5 @@ export const App = (props, { state, effects }) => {
   );
 };
 
-App.contextTypes = contextTypes;
 
-
-export default addState(App);
+export default addState(injectState(App));

--- a/example/src/child-component/index.js
+++ b/example/src/child-component/index.js
@@ -1,4 +1,4 @@
-import { withState, contextTypes } from "../../..";
+import { withState, injectState } from "../../..";
 import { default as React } from "react";
 
 import * as effectDefs from "./effects";
@@ -7,7 +7,7 @@ import computed from "./computed";
 
 export const addState = withState({ effects: effectDefs, initialState, computed });
 
-export const ChildComponent = (props, { state, effects }) => (
+export const ChildComponent = ({ state, effects }) => (
   <div>
     <div>This is a subcomponent, with its own state!</div>
     <div>{`Here is a local value '${state.localValue}' and its computed length '${state.localValueLength}'`}</div>
@@ -20,6 +20,4 @@ export const ChildComponent = (props, { state, effects }) => (
   </div>
 );
 
-ChildComponent.contextTypes = contextTypes;
-
-export default addState(ChildComponent);
+export default addState(injectState(ChildComponent));

--- a/src/context.js
+++ b/src/context.js
@@ -2,8 +2,5 @@ import { PropTypes } from "react";
 
 
 export const contextTypes = {
-  state: PropTypes.object,
-  effects: PropTypes.object,
-  __captureState__: PropTypes.any,
-  __getNextContainerState__: PropTypes.func
+  freactal: PropTypes.object
 };

--- a/src/freactal.js
+++ b/src/freactal.js
@@ -81,15 +81,16 @@ export const withState = opts => StatelessComponent => {
       );
     }
 
-    pushUpdate (afterUpdate, changedKeys) {
-      // In an SSR environment, the component will not yet have rendered, and the child
-      // context will not yet be generated.  The subscribers don't need to be notified,
-      // as they will contain correct context on their initial render.
-      if (this.childContext) {
-        Object.assign(this.childContext, this.buildContext(changedKeys));
-        this.subscribers.forEach(cb => cb && cb());
-      }
-      afterUpdate();
+    pushUpdate (changedKeys) {
+      return Promise.resolve().then(() => {
+        // In an SSR environment, the component will not yet have rendered, and the child
+        // context will not yet be generated.  The subscribers don't need to be notified,
+        // as they will contain correct context on their initial render.
+        if (this.childContext) {
+          Object.assign(this.childContext, this.buildContext(changedKeys));
+          this.subscribers.forEach(cb => cb && cb());
+        }
+      });
     }
 
     getState () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export { withState } from "./freactal";
-export { contextTypes } from "./context";
 export { hydrate } from "./state";
+export { injectState } from "./inject";

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,0 +1,84 @@
+import { default as React, Component } from "react";
+
+import { contextTypes } from "./context";
+
+
+export const injectState = (StatelessComponent, keys = null) => {
+  const auto = !keys;
+
+  let shouldUpdate = () => true;
+  if (keys) {
+    shouldUpdate = changedKeys => keys.reduce((memo, key) => memo || changedKeys[key], false);
+  } else {
+    shouldUpdate = (changedKeys, usedKeys) => usedKeys ?
+      Object.keys(usedKeys)
+        .filter(key => usedKeys[key])
+        .reduce((memo, key) => memo || changedKeys[key], false) :
+      true;
+  }
+
+  class InjectStateHoc extends Component {
+    constructor (...args) {
+      super(...args);
+      if (!this.context.freactal) {
+        throw new Error("Attempted to inject state without parent Freactal state container.");
+      }
+    }
+
+    componentDidMount () {
+      this.mounted = true;
+      this.unsubscribe = this.context.freactal.subscribe(this.update.bind(this));
+    }
+
+    componentWillReceiveProps () {
+      this.usedKeys = null;
+    }
+
+    componentWillUnmount () {
+      this.mounted = false;
+      this.unsubscribe();
+    }
+
+    update () {
+      if (this.mounted && shouldUpdate(this.context.freactal.changedKeys, this.usedKeys)) {
+        this.forceUpdate();
+      }
+    }
+
+    getTrackedState () {
+      const state = this.context.freactal.state;
+      const trackedState = Object.create(null);
+      const usedKeys = this.usedKeys = Object.create(null);
+
+      Object.keys(state).forEach(key => {
+        usedKeys[key] = false;
+
+        Object.defineProperty(trackedState, key, {
+          enumerable: true,
+          get () {
+            usedKeys[key] = true;
+            return state[key];
+          }
+        });
+      });
+
+      return trackedState;
+    }
+
+    render () {
+      const state = auto ? this.getTrackedState() : this.context.freactal.state;
+
+      return (
+        <StatelessComponent
+          {...this.props}
+          state={state}
+          effects={this.context.freactal.effects}
+        />
+      );
+    }
+  }
+
+  InjectStateHoc.contextTypes = contextTypes;
+
+  return InjectStateHoc;
+};

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -5,7 +5,7 @@ import { resolvePromiseTree } from "./resolve-promise-tree";
 export const initialize = rootNode => {
   const state = [];
   const renderingContext = {
-    __captureState__: containerState => state.push(containerState)
+    freactal: { captureState: containerState => state.push(containerState) }
   };
 
   const renderTree = partialRender(rootNode, renderingContext);

--- a/src/state.js
+++ b/src/state.js
@@ -96,14 +96,18 @@ export class HocState {
   setState (newState) {
     const oldState = this.state;
     const allKeys = Object.keys(Object.assign({}, oldState, newState));
-    allKeys.forEach(key => this.set(key, newState[key]));
-    return new Promise(resolve => this.onChange(resolve));
+    const changedKeys = Object.create(null);
+    allKeys.forEach(key => {
+      this.set(key, newState[key]);
+      changedKeys[key] = oldState[key] === newState[key];
+    });
+    return new Promise(resolve => this.onChange(resolve, changedKeys));
   }
 }
 
 export const hydrate = bootstrapState => (props, context) => {
-  if (context.__getNextContainerState__) {
-    return context.__getNextContainerState__();
+  if (context.freactal && context.freactal.getNextContainerState) {
+    return context.freactal.getNextContainerState();
   }
 
   let containerIdx = 1;

--- a/src/state.js
+++ b/src/state.js
@@ -101,7 +101,7 @@ export class HocState {
       this.set(key, newState[key]);
       changedKeys[key] = oldState[key] === newState[key];
     });
-    return new Promise(resolve => this.onChange(resolve, changedKeys));
+    return this.onChange(changedKeys);
   }
 }
 


### PR DESCRIPTION
This closes #3 and some other issues discussed with @kenwheeler.

What this does:
- Previously, `state` and `effects` were exposed to the user directly through the context.  This was counter to recommendations from the React team, and I have slowly realized why :).  That has been removed.
- Instead, an `injectState` function is exposed to inject `state` and `effects` props into the wrapped component.
- `injectState`-wrapped components subscribe to changes to the state container (and recursively, up the tree), which means that the entire tree will not re-render when the root state changes.
- `injectState` is able to detect which state keys you use in its wrapped component, and will only re-render if _those_ keys change in the state container.
- You can override the above behavior by passing a second `keys` argument of shape `["key1", "key2"]` to `injectState`.  When specified, this disables the auto-detect feature and instead updates the wrapped component when the specified keys change.

 The README has not seen changes yet - however, it'd be great to get feedback based on the changes to `example/`.  If this is the way forward, there will be code comments and documentation updates before this is merged.

@kenwheeler @aweary @ryan-roemer @baer @tptee @exogen @bmathews @chrisbolin 