### PR TITLE
Fix component names in composition example

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ These are constraints that `freactal` aims to address.  Let's take a look at a m
 ```javascript
 const Child = injectState(({ state }) => (
   <div>
-    This is the GrandChild.
+    This is the Child.
     {state.fromParent}
     {state.fromGrandParent}
   </div>
@@ -540,7 +540,7 @@ const Parent = provideState({
   initialState: () => ({ fromParent: "ParentValue" })
 })(() => (
   <div>
-    This is the Child.
+    This is the Parent.
     <GrandChild />
   </div>
 ));
@@ -549,8 +549,8 @@ const GrandParent = provideState({
   initialState: () => ({ fromGrandParent: "GrandParentValue" })
 })(() => (
   <div>
-    This is the Parent.
-    <Child />
+    This is the GrandParent.
+    <Parent />
   </div>
 ));
 ```

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ const Parent = provideState({
 })(() => (
   <div>
     This is the Parent.
-    <GrandChild />
+    <Child />
   </div>
 ));
 

--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ Child effects can also trigger parent effects.  Let's say your UX team has indic
 ```javascript
 const Child = injectState(({ state, effects }) => (
   <div>
-    This is the GrandChild.
+    This is the Child.
     {state.fromParent}
     {state.fromGrandParent}
     <button
@@ -593,8 +593,8 @@ const Parent = provideState({
   }
 })(() => (
   <div>
-    This is the Child.
-    <GrandChild />
+    This is the Parent.
+    <Child />
   </div>
 ));
 
@@ -606,8 +606,8 @@ const GrandParent = provideState({
   }
 })(() => (
   <div>
-    This is the Parent.
-    <Child />
+    This is the GrandParent.
+    <Parent />
   </div>
 ));
 ```


### PR DESCRIPTION
The component names in the  "Composing multiple state containers" code sample seem to be incorrect based on the explanation following the sample.