### PR TITLE
Fix example effects in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ The first of those differences relates to asychronicity.  Under the hood, `freac
 ```javascript
 addOne: () => state => Object.assign({}, state, { counter: state.counter + 1 })
 /* vs */
-addOne: () => state => Promise.resolve(Object.assign({}, state, { counter: state.counter + 1 }))
+addOne: () => Promise.resolve(state => Object.assign({}, state, { counter: state.counter + 1 }))
 /* vs */
-addOne: () => state => new Promise(resolve => resolve(Object.assign({}, state, { counter: state.counter + 1 })))
+addOne: () => new Promise(resolve => resolve(state => Object.assign({}, state, { counter: state.counter + 1 })))
 ```
 
 To put it explicitly, the value you provide for each key in your `effects` object is:


### PR DESCRIPTION
If I’m reading the documentation correctly, and an effect is a “(1) function that … returns (2) a promise that resolves to (3) a function that takes in state and returns (4) the updated state,” then I think the second and third examples are wrapping the state transform in the Promise in the wrong order… reversing (2) and (3).

See: https://github.com/FormidableLabs/freactal#transforming-state-cont

My changes are consistent with the subsequent README example:

```javascript
updatePosts: () => fetch("/api/posts")
  .then(result => result.json())
  .then(({ posts }) => state => Object.assign({}, state, { posts }))
```

... in that the `state => transform( state )` is what the `Promise` resolves to.

_I'm brand new to this repo, so forgive me if this pull request is premature._