### PR TITLE
Remove React.Proptypes in favor of 'prop-types' to support React 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,14 @@
     "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
-    "react": "^15.4.2",
-    "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.4.2",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/context.js
+++ b/src/context.js
@@ -1,6 +1,5 @@
-import { PropTypes } from "react";
-
+import { object } from "prop-types";
 
 export const contextTypes = {
-  freactal: PropTypes.object
+  freactal: object
 };


### PR DESCRIPTION
Update enzyme, react, react-dom dev dependencies to support react 15.5 for testing. Remove react-addons-test-utils and add react-test-renderer to support newer version of enzyme.