### PR TITLE
Declare react as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "url": "https://github.com/divmain/freactal/issues"
   },
   "homepage": "https://github.com/divmain/freactal#readme",
+  "peerDependencies": {
+    "react": "^15.5.4"
+  },
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-eslint": "^7.2.1",


### PR DESCRIPTION
The two main APIs, `provideState` and `injectState`, are Higher Order Components which rely on React.

Therefore `react` is not just a devDependency of this library, it's needed for this library to operate.