### PR TITLE
import only needed modules from lodash

### DIFF
--- a/src/server/context.js
+++ b/src/server/context.js
@@ -1,4 +1,5 @@
-import { assign, keys } from "lodash";
+import assign from "lodash/assign";
+import keys from "lodash/keys";
 
 /**
  * Code originally borrowed from the Rapscallion project:

--- a/src/server/set-state.js
+++ b/src/server/set-state.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-invalid-this */
-import { isFunction, assign } from "lodash";
+import isFunction from "lodash/isFunction";
+import assign from "lodash/assign";
 
 
 /**


### PR DESCRIPTION
When writing things like `import { assign, keys } from "lodash";` you're actually importing the whole `lodash` module and then just accessing its `assign` and `keys` methods.

But lodash exposes all its methods as [separate modules](https://github.com/lodash/lodash/tree/0b311640082abb2350914776375a919ca544a2ab#installation).

Therefore by writing the following instead:

```javascript
import assign from "lodash/assign";
import keys from "lodash/keys";
```

you significantly reduce bundle size by only importing what you actually need.

