### PR TITLE
Let middleware know the next state

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -1,7 +1,12 @@
 export const getEffects = (hocState, effectDefs, parentEffects) => {
-  const applyReducer = reducer => reducer ?
-    hocState.setState(reducer(hocState.state)) :
-    null;
+  const applyReducer = reducer => {
+    const result = reducer ? reducer(hocState.state) : null;
+    if (result) {
+      hocState.setState(result);
+    }
+
+    return result;
+  };
 
   const effects = Object.keys(effectDefs).reduce((memo, effectKey) => {
     const effectFn = effectDefs[effectKey];


### PR DESCRIPTION
In the previous logic, middleware can not know the next state so that it can't add middleware like logger to log the state changes.

``` javascript
provideState({
  middleware: [
    freactalCxt => Object.assign({}, freactalCxt, {
      effects: Object.keys(freactalCxt.effects).reduce((memo, key) => {
        memo[key] = (...args) => {
          console.log("Effect started", key, args);
          return freactalCxt.effects[key](...args).then(result => {
            // result will be [undefined] cause it is call by React's forceUpdate
            console.log("Effect completed", key);
            return result;
          })
        };
        return memo;
      }, {})
    })
  ]
})
```
