### PR TITLE
passes props to initialize effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,7 +865,7 @@ provideState({
 
 ##### `initialize`
 
-Each state container can define a special effect called `initialize`.  This effect will be implicitly invoked in two circumstances:
+Each state container can define a special effect called `initialize`.  This effect has props passed in as a second argument and will be implicitly invoked in two circumstances:
 
 1. During SSR, each state container with an `initialize` effect will invoke it, and the rendering process will await the resolution of that effect before continuing with rendering.
 2. When running in the browser, each state container with an `initialize` effect will invoke it when the container is mounted into the DOM.

--- a/src/provide.js
+++ b/src/provide.js
@@ -30,7 +30,7 @@ export class BaseStatefulComponent extends Component {
   }
 
   componentDidMount () {
-    if (this.effects.initialize) { this.effects.initialize(); }
+    if (this.effects.initialize) { this.effects.initialize(this.props); }
     this.unsubscribe = this.context.freactal ?
       this.context.freactal.subscribe(this.relayUpdate.bind(this)) :
       () => {};


### PR DESCRIPTION
Initialize w/o props is cripplingly difficult to use.

Passing in props by default allows for loading resources based on a router match:

```
initialize: (effects, props) ->
      Api.find('user', props.match.params.userName)
      .then (result) -> mergeIntoState user: Immutable.fromJS(result)
```

