### PR TITLE
Fix: Hides deprecation warning when using correct method

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ And then our state template:
 ```javascript
 /*** state.js ***/
 
-import { provideState, softUpdate } from "freactal";
+import { provideState, update } from "freactal";
 
 export const wrapComponentWithState = provideState({
   initialState: () => ({
@@ -1033,7 +1033,7 @@ effects: {
 
 ### `mergeIntoState`
 
-Both `hardUpdate` and `softUpdate` are intended for synchronous updates only.  But writing out a state-update function for asynchronous effects can get tedious.  That's where `mergeIntoState` comes in.
+`update` is intended for synchronous updates only.  But writing out a state-update function for asynchronous effects can get tedious.  That's where `mergeIntoState` comes in.
 
 ```javascript
 mergeIntoState(newData)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,23 +6,23 @@ const displayDeprecationMessage = () => {
   console.log("Both `hardUpdate` and `softUpdate` are deprecated.  Please use `update` instead.");
 };
 
-export const hardUpdate = newState => {
-  displayDeprecationMessage();
+export const hardUpdate = (newState, showWarning = true) => {
+  if (showWarning) { displayDeprecationMessage(); }
   return () => state => Object.assign({}, state, newState);
 };
 
-export const softUpdate = fn => {
-  displayDeprecationMessage();
+export const softUpdate = (fn, showWarning = true) => {
+  if (showWarning) { displayDeprecationMessage(); }
   return (effects, ...args) => state => Object.assign({}, state, fn(state, ...args));
 };
 
 export const update = fnOrNewState => {
   if (typeof fnOrNewState === "function") {
-    return softUpdate(fnOrNewState);
+    return softUpdate(fnOrNewState, false);
   }
 
   if (typeof fnOrNewState === "object") {
-    return hardUpdate(fnOrNewState);
+    return hardUpdate(fnOrNewState, false);
   }
 
   throw new Error("update must receive a reducer function or object to merge as its argument.");


### PR DESCRIPTION
This hides the deprecation warning in the console when using the new update helper.

This also removes all references to the deprecated methods in the README