### PR TITLE
Enhancement: props documentation in initialstate and compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,8 @@ Component props can be passed to `initialState` like so :
 ```javascript
 provideState({
   initialState: ({ value }) => ({
-    a: value
+    a: value,
+    b: "set here"
   })
 })
 ```

--- a/README.md
+++ b/README.md
@@ -837,6 +837,15 @@ provideState({
   })
 })
 ```
+Component props can be passed to `initialState` like so : 
+
+```javascript
+provideState({
+  initialState: ({ value }) => ({
+    a: value
+  })
+})
+```
 
 
 #### `effects`
@@ -891,6 +900,8 @@ provideState({
   }
 })
 ```
+
+Props can't be passed to `computed` 
 
 #### `middleware`
 


### PR DESCRIPTION
While i'm working with **freactal** I noticed that Props can't be passed in `computed` and there is no documentation on it.
Also I wanted to pass props in `initialState` but I didn't knew how till my manager checked the source code.
So I added some lines to the doc in order to clarify things for future users :)
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters adhere to the following:

- [x] <!-- checklist item; required -->I have read and will comply with the [contribution guidelines](https://github.com/FormidableLabs/freactal/blob/master/CONTRIBUTE.md).
 _(required)_
- [x] <!-- checklist item; required -->I have read and will comply with the [code of conduct](https://github.com/FormidableLabs/freactal/blob/master/CONTRIBUTE.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [ ] <!-- semver --> patch
- [x] <!-- semver --> documentation only

